### PR TITLE
Add interactive card connectors and session support

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -27,10 +27,11 @@ body {
     width: 170px; /* Increased from 150px */
     padding: 10px;
     background: #fff;
-    border: 2px solid #ccc; 
+    border: 2px solid #ccc;
     border-radius: 8px;
     cursor: grab;
     box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    z-index: 1;
 }
 
 .card .card-title {
@@ -135,6 +136,42 @@ body {
 
 .color-swatch.selected {
     border: 2px solid #3498db;
+}
+
+/* --- Connection Layer --- */
+.connection-layer {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: auto;
+    z-index: 0;
+}
+
+.connector-path {
+    stroke: #555;
+    stroke-width: 2px;
+    fill: none;
+    pointer-events: stroke;
+    transition: stroke 0.2s;
+}
+
+.connector-path:hover {
+    stroke: #2c3e50;
+}
+
+.connector-label {
+    fill: #2c3e50;
+    font-size: 12px;
+    pointer-events: auto;
+    cursor: pointer;
+    user-select: none;
+}
+
+.temp-connector {
+    stroke-dasharray: 6 4;
+    opacity: 0.7;
 }
 
 /* --- Modal Component --- */

--- a/js/app.js
+++ b/js/app.js
@@ -22,8 +22,8 @@ document.getElementById("save-screenshot").addEventListener("click", () => {
 });
 
 document.getElementById("save-session").addEventListener("click", () => {
-    const cards = CardModel.getCards();
-    const dataStr = JSON.stringify(cards, null, 2);
+    const sessionState = CardModel.getState();
+    const dataStr = JSON.stringify(sessionState, null, 2);
     const blob = new Blob([dataStr], { type: "application/json" });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");

--- a/js/model.js
+++ b/js/model.js
@@ -1,6 +1,8 @@
 const CardModel = (() => {
     let cards = [];
+    let connectors = [];
     let idCounter = 1;
+    let connectorIdCounter = 1;
 
     function addCard(title = "New Title", blurb = "Click to edit...") {
         const card = {
@@ -26,21 +28,133 @@ const CardModel = (() => {
         return cards;
     }
 
-        function loadCards(loadedData) {
-        if (Array.isArray(loadedData)) {
-            cards = loadedData;
-            idCounter = Math.max(0, ...cards.map(c => c.id)) + 1;
-        } else {
-            console.error("Failed to load session: Data is not valid.");
+    function getConnectors() {
+        return connectors;
+    }
+
+    function addConnector(fromCardId, toCardId, type = 'relates to') {
+        const fromExists = cards.some(c => c.id === fromCardId);
+        const toExists = cards.some(c => c.id === toCardId);
+        if (!fromExists || !toExists || fromCardId === toCardId) {
+            return null;
+        }
+
+        const normalizedType = type && type.trim() ? type.trim() : 'relates to';
+        const duplicate = connectors.some(connector =>
+            connector.fromCardId === fromCardId &&
+            connector.toCardId === toCardId &&
+            connector.type.toLowerCase() === normalizedType.toLowerCase()
+        );
+        if (duplicate) {
+            return null;
+        }
+
+        const connector = {
+            id: connectorIdCounter++,
+            fromCardId,
+            toCardId,
+            type: normalizedType
+        };
+
+        connectors.push(connector);
+        return connector;
+    }
+
+    function updateConnector(id, data) {
+        const connector = connectors.find(c => c.id === id);
+        if (connector) Object.assign(connector, data);
+    }
+
+    function deleteConnector(id) {
+        const index = connectors.findIndex(c => c.id === id);
+        if (index > -1) {
+            connectors.splice(index, 1);
         }
     }
 
-        function deleteCard(id) {
+    function getConnector(id) {
+        return connectors.find(c => c.id === id);
+    }
+
+    function getState() {
+        return {
+            cards: JSON.parse(JSON.stringify(cards)),
+            connectors: JSON.parse(JSON.stringify(connectors))
+        };
+    }
+
+    function loadCards(loadedData) {
+        if (Array.isArray(loadedData)) {
+            cards = loadedData;
+            connectors = [];
+        } else if (loadedData && Array.isArray(loadedData.cards)) {
+            cards = loadedData.cards;
+            const cardIds = new Set(cards.map(card => card.id));
+            if (Array.isArray(loadedData.connectors)) {
+                const seen = new Set();
+                const sanitized = [];
+                loadedData.connectors.forEach(connector => {
+                    if (!cardIds.has(connector.fromCardId) || !cardIds.has(connector.toCardId) || connector.fromCardId === connector.toCardId) {
+                        return;
+                    }
+                    const type = connector.type && typeof connector.type === 'string' && connector.type.trim() ? connector.type.trim() : 'relates to';
+                    const key = `${connector.fromCardId}->${connector.toCardId}:${type.toLowerCase()}`;
+                    if (seen.has(key)) {
+                        return;
+                    }
+                    seen.add(key);
+                    sanitized.push({
+                        id: typeof connector.id === 'number' && Number.isFinite(connector.id) ? connector.id : null,
+                        fromCardId: connector.fromCardId,
+                        toCardId: connector.toCardId,
+                        type
+                    });
+                });
+
+                let maxId = 0;
+                sanitized.forEach(connector => {
+                    if (typeof connector.id === 'number') {
+                        maxId = Math.max(maxId, connector.id);
+                    }
+                });
+                let nextId = maxId + 1;
+                connectors = sanitized.map(connector => ({
+                    id: typeof connector.id === 'number' ? connector.id : nextId++,
+                    fromCardId: connector.fromCardId,
+                    toCardId: connector.toCardId,
+                    type: connector.type
+                }));
+            } else {
+                connectors = [];
+            }
+        } else {
+            console.error("Failed to load session: Data is not valid.");
+            return;
+        }
+
+        idCounter = Math.max(0, ...cards.map(c => c.id)) + 1;
+        connectorIdCounter = Math.max(0, ...connectors.map(c => c.id)) + 1;
+    }
+
+    function deleteCard(id) {
         const cardIndex = cards.findIndex(c => c.id === id);
         if (cardIndex > -1) {
             cards.splice(cardIndex, 1);
+            connectors = connectors.filter(connector => connector.fromCardId !== id && connector.toCardId !== id);
         }
     }
 
-    return { addCard, updateCard, getCards, loadCards, deleteCard };;
+    return {
+        addCard,
+        updateCard,
+        getCards,
+        getConnectors,
+        addConnector,
+        updateConnector,
+        deleteConnector,
+        getConnector,
+        getState,
+        loadCards,
+        deleteCard
+    };
 })();

--- a/js/ui/cards.js
+++ b/js/ui/cards.js
@@ -1,5 +1,193 @@
 const CardUI = (() => {
     const container = document.getElementById("card-container");
+    const svgNS = "http://www.w3.org/2000/svg";
+    const LONG_PRESS_DURATION = 500;
+    const MOVE_THRESHOLD = 6;
+    const RELATION_SUGGESTIONS = [
+        'relates to',
+        'type of',
+        'reminds me of',
+        'leads to',
+        'supports'
+    ];
+
+    let connectionLayer = null;
+    let tempConnectionPath = null;
+    let activeConnection = null;
+    const cardElements = new Map();
+
+    function ensureConnectionLayer() {
+        if (!connectionLayer) {
+            connectionLayer = document.createElementNS(svgNS, 'svg');
+            connectionLayer.classList.add('connection-layer');
+            container.appendChild(connectionLayer);
+        }
+
+        const rect = container.getBoundingClientRect();
+        connectionLayer.setAttribute('width', rect.width);
+        connectionLayer.setAttribute('height', rect.height);
+        connectionLayer.setAttribute('viewBox', `0 0 ${rect.width} ${rect.height}`);
+
+        return connectionLayer;
+    }
+
+    function getContainerRect() {
+        return container.getBoundingClientRect();
+    }
+
+    function getCardCenter(cardId) {
+        const el = cardElements.get(cardId);
+        if (!el) return null;
+        const containerRect = getContainerRect();
+        const rect = el.getBoundingClientRect();
+        return {
+            x: rect.left - containerRect.left + rect.width / 2,
+            y: rect.top - containerRect.top + rect.height / 2
+        };
+    }
+
+    function computeControlPoint(start, end) {
+        const midX = (start.x + end.x) / 2;
+        const midY = (start.y + end.y) / 2;
+        const dx = end.x - start.x;
+        const dy = end.y - start.y;
+        const distance = Math.sqrt(dx * dx + dy * dy) || 1;
+        const offset = Math.min(80, distance / 3);
+        const offsetX = (-dy / distance) * offset;
+        const offsetY = (dx / distance) * offset;
+        return {
+            x: midX + offsetX,
+            y: midY + offsetY
+        };
+    }
+
+    function computeQuadraticPoint(start, control, end, t) {
+        const oneMinusT = 1 - t;
+        const x = oneMinusT * oneMinusT * start.x + 2 * oneMinusT * t * control.x + t * t * end.x;
+        const y = oneMinusT * oneMinusT * start.y + 2 * oneMinusT * t * control.y + t * t * end.y;
+        return { x, y };
+    }
+
+    function editConnector(connectorId) {
+        const connector = CardModel.getConnector(connectorId);
+        if (!connector) return;
+        const suggestionText = `Suggestions: ${RELATION_SUGGESTIONS.join(', ')}`;
+        const newType = prompt(`Edit relationship description (current: "${connector.type}")\n${suggestionText}`, connector.type);
+        if (newType === null) return;
+        const trimmed = newType.trim();
+        CardModel.updateConnector(connectorId, { type: trimmed || RELATION_SUGGESTIONS[0] });
+        renderConnections();
+    }
+
+    function deleteConnectorWithConfirm(connectorId) {
+        if (!confirm('Delete this connector?')) return;
+        CardModel.deleteConnector(connectorId);
+        renderConnections();
+    }
+
+    function renderConnections() {
+        const layer = ensureConnectionLayer();
+        layer.innerHTML = '';
+
+        CardModel.getConnectors().forEach(connector => {
+            const start = getCardCenter(connector.fromCardId);
+            const end = getCardCenter(connector.toCardId);
+            if (!start || !end) {
+                return;
+            }
+
+            const control = computeControlPoint(start, end);
+            const path = document.createElementNS(svgNS, 'path');
+            path.classList.add('connector-path');
+            path.setAttribute('d', `M ${start.x} ${start.y} Q ${control.x} ${control.y} ${end.x} ${end.y}`);
+            path.dataset.connectorId = connector.id;
+            layer.appendChild(path);
+
+            const midPoint = computeQuadraticPoint(start, control, end, 0.5);
+            const text = document.createElementNS(svgNS, 'text');
+            text.classList.add('connector-label');
+            text.setAttribute('x', midPoint.x);
+            text.setAttribute('y', midPoint.y - 6);
+            text.setAttribute('text-anchor', 'middle');
+            text.setAttribute('dominant-baseline', 'central');
+            text.textContent = connector.type;
+            text.dataset.connectorId = connector.id;
+            layer.appendChild(text);
+
+            const editHandler = () => editConnector(connector.id);
+            const deleteHandler = (event) => {
+                event.preventDefault();
+                deleteConnectorWithConfirm(connector.id);
+            };
+
+            path.addEventListener('click', editHandler);
+            text.addEventListener('click', editHandler);
+            path.addEventListener('contextmenu', deleteHandler);
+            text.addEventListener('contextmenu', deleteHandler);
+        });
+
+        if (activeConnection && tempConnectionPath) {
+            layer.appendChild(tempConnectionPath);
+        }
+    }
+
+    function startConnectionDrag(cardId, pointerEvent) {
+        const start = getCardCenter(cardId);
+        if (!start) return;
+        ensureConnectionLayer();
+
+        activeConnection = {
+            fromCardId: cardId,
+            start
+        };
+
+        tempConnectionPath = document.createElementNS(svgNS, 'path');
+        tempConnectionPath.classList.add('connector-path', 'temp-connector');
+        connectionLayer.appendChild(tempConnectionPath);
+        updateConnectionDrag(pointerEvent);
+    }
+
+    function updateConnectionDrag(pointerEvent) {
+        if (!activeConnection || !tempConnectionPath) return;
+        const containerRect = getContainerRect();
+        const end = {
+            x: pointerEvent.clientX - containerRect.left,
+            y: pointerEvent.clientY - containerRect.top
+        };
+        const { start } = activeConnection;
+        const control = computeControlPoint(start, end);
+        tempConnectionPath.setAttribute('d', `M ${start.x} ${start.y} Q ${control.x} ${control.y} ${end.x} ${end.y}`);
+    }
+
+    function finishConnectionDrag(targetCardId) {
+        if (tempConnectionPath && tempConnectionPath.parentNode) {
+            tempConnectionPath.parentNode.removeChild(tempConnectionPath);
+        }
+        tempConnectionPath = null;
+
+        if (activeConnection && targetCardId && targetCardId !== activeConnection.fromCardId) {
+            const suggestionText = `Suggestions: ${RELATION_SUGGESTIONS.join(', ')}`;
+            const relationType = prompt(`Relationship type between cards?\n${suggestionText}`, RELATION_SUGGESTIONS[0]);
+            if (relationType !== null) {
+                const trimmed = relationType.trim();
+                const created = CardModel.addConnector(activeConnection.fromCardId, targetCardId, trimmed || RELATION_SUGGESTIONS[0]);
+                if (!created) {
+                    alert('A connector with this relationship already exists between the selected cards.');
+                }
+                renderConnections();
+            }
+        }
+
+        activeConnection = null;
+    }
+
+    function cancelActiveConnection() {
+        if (tempConnectionPath && tempConnectionPath.parentNode) {
+            tempConnectionPath.parentNode.removeChild(tempConnectionPath);
+        }
+        tempConnectionPath = null;
+        activeConnection = null;
+    }
 
     function createCardElement(card) {
         const div = document.createElement("div");
@@ -8,8 +196,11 @@ const CardUI = (() => {
         div.style.left = card.x + "px";
         div.style.top = card.y + "px";
         div.style.backgroundColor = card.color;
+        div.dataset.cardId = card.id;
+        cardElements.set(card.id, div);
 
-        // --- TITLE AND BLURB STRUCTURE ---
+        let suppressClick = false;
+
         const titleDiv = document.createElement("div");
         titleDiv.classList.add("card-title");
         titleDiv.textContent = card.title;
@@ -20,16 +211,18 @@ const CardUI = (() => {
         blurbDiv.textContent = card.blurb;
         div.appendChild(blurbDiv);
 
-        // --- TOUCH-FRIENDLY EDITING LOGIC ---
         titleDiv.addEventListener("click", () => {
+            if (suppressClick) return;
             const newTitle = prompt("Edit Title:", card.title);
             if (newTitle !== null && newTitle.trim() !== "") {
                 card.title = newTitle;
                 titleDiv.textContent = newTitle;
+                renderConnections();
             }
         });
 
         blurbDiv.addEventListener("click", () => {
+            if (suppressClick) return;
             const newBlurb = prompt("Edit Blurb:", card.blurb);
             if (newBlurb !== null) {
                 card.blurb = newBlurb;
@@ -37,7 +230,6 @@ const CardUI = (() => {
             }
         });
 
-        // --- NUCLEUS TOGGLE ---
         div.addEventListener("dblclick", (e) => {
             if (e.target === div) {
                 card.nucleus = !card.nucleus;
@@ -45,13 +237,12 @@ const CardUI = (() => {
             }
         });
 
-        // --- DRAG HANDLE ---
         const dragHandle = document.createElement("div");
         dragHandle.classList.add("drag-handle");
         dragHandle.innerHTML = "⠿";
+        dragHandle.style.touchAction = 'none';
         div.appendChild(dragHandle);
 
-        // --- DELETE BUTTON ---
         const deleteBtn = document.createElement("div");
         deleteBtn.classList.add("delete-btn");
         deleteBtn.innerHTML = "&times;";
@@ -60,63 +251,52 @@ const CardUI = (() => {
         deleteBtn.addEventListener("click", () => {
             if (confirm("Are you sure you want to permanently delete this card?")) {
                 CardModel.deleteCard(card.id);
-                CardUI.render();
+                render();
             }
         });
 
-// --- UNIFIED DRAGGING LOGIC (TOUCH & MOUSE COMPATIBLE) ---
-        let offsetX, offsetY, dragging = false;
+        let dragging = false;
+        let dragPointerId = null;
+        let offsetX = 0;
+        let offsetY = 0;
 
-        function dragStart(e) {
+        dragHandle.addEventListener('pointerdown', (event) => {
+            if (event.button !== undefined && event.button !== 0) return;
+            cancelActiveConnection();
             dragging = true;
-            // Prevent default touch action (like scrolling the page)
-            if (e.type === 'touchstart') {
-                e.preventDefault();
-            }
-
-            // Get coordinates for either mouse or touch
-            const clientX = e.type === 'touchstart' ? e.touches[0].clientX : e.clientX;
-            const clientY = e.type === 'touchstart' ? e.touches[0].clientY : e.clientY;
-            
-            const cardRect = div.getBoundingClientRect();
-            offsetX = clientX - cardRect.left;
-            offsetY = clientY - cardRect.top;
-            
+            dragPointerId = event.pointerId;
+            const rect = div.getBoundingClientRect();
+            offsetX = event.clientX - rect.left;
+            offsetY = event.clientY - rect.top;
             div.style.cursor = "grabbing";
-            e.stopPropagation();
-        }
+            dragHandle.setPointerCapture(dragPointerId);
+            event.preventDefault();
+        });
 
-        function dragMove(e) {
-            if (dragging) {
-                // Get coordinates for either mouse or touch
-                const clientX = e.type === 'touchmove' ? e.touches[0].clientX : e.clientX;
-                const clientY = e.type === 'touchmove' ? e.touches[0].clientY : e.clientY;
+        dragHandle.addEventListener('pointermove', (event) => {
+            if (!dragging || event.pointerId !== dragPointerId) return;
+            const containerRect = getContainerRect();
+            card.x = event.clientX - containerRect.left - offsetX;
+            card.y = event.clientY - containerRect.top - offsetY;
+            div.style.left = card.x + "px";
+            div.style.top = card.y + "px";
+            renderConnections();
+        });
 
-                card.x = clientX - offsetX;
-                card.y = clientY - offsetY;
-                div.style.left = card.x + "px";
-                div.style.top = card.y + "px";
+        function endDrag(event) {
+            if (event.pointerId !== dragPointerId) return;
+            dragging = false;
+            div.style.cursor = "grab";
+            if (dragHandle.hasPointerCapture(dragPointerId)) {
+                dragHandle.releasePointerCapture(dragPointerId);
             }
+            dragPointerId = null;
+            renderConnections();
         }
 
-        function dragEnd() {
-            if (dragging) {
-                dragging = false;
-                div.style.cursor = "grab";
-            }
-        }
+        dragHandle.addEventListener('pointerup', endDrag);
+        dragHandle.addEventListener('pointercancel', endDrag);
 
-        // Attach both mouse and touch listeners
-        dragHandle.addEventListener("mousedown", dragStart);
-        dragHandle.addEventListener("touchstart", dragStart, { passive: false });
-
-        document.addEventListener("mousemove", dragMove);
-        document.addEventListener("touchmove", dragMove);
-
-        document.addEventListener("mouseup", dragEnd);
-        document.addEventListener("touchend", dragEnd);
-
-        // --- COLOR PALETTE LOGIC ---
         const colors = ['#ffffff', '#fff0f0', '#f0faff', '#f5f5dc', '#f0fff0'];
         const palette = document.createElement('div');
         palette.classList.add('color-palette');
@@ -132,18 +312,19 @@ const CardUI = (() => {
             swatch.addEventListener('click', () => {
                 card.color = color;
                 div.style.backgroundColor = color;
-
                 palette.querySelectorAll('.color-swatch').forEach(s => s.classList.remove('selected'));
                 swatch.classList.add('selected');
+                renderConnections();
             });
+
             palette.appendChild(swatch);
         });
+
         div.appendChild(palette);
 
-        // --- TAGS LOGIC ---
         const tagContainer = document.createElement("div");
         tagContainer.classList.add("tags");
-        updateTagDisplay();
+        div.appendChild(tagContainer);
 
         function updateTagDisplay() {
             tagContainer.innerHTML = "";
@@ -178,14 +359,120 @@ const CardUI = (() => {
             tagContainer.appendChild(addTagButton);
         }
 
-        div.appendChild(tagContainer);
+        updateTagDisplay();
+
+        let longPressTimer = null;
+        let connectionPointerId = null;
+        let connectionStart = null;
+        let connectionStarted = false;
+        let lastPointerEvent = null;
+
+        function shouldIgnoreConnectionStart(target) {
+            return Boolean(
+                target.closest('.drag-handle') ||
+                target.closest('.delete-btn') ||
+                target.closest('.color-palette') ||
+                target.closest('.tag')
+            );
+        }
+
+        function clearLongPressTimer() {
+            if (longPressTimer) {
+                clearTimeout(longPressTimer);
+                longPressTimer = null;
+            }
+        }
+
+        function endConnectionSequence(event, cancelled = false) {
+            if (connectionPointerId === null || event.pointerId !== connectionPointerId) {
+                return;
+            }
+
+            clearLongPressTimer();
+            if (div.hasPointerCapture(connectionPointerId)) {
+                div.releasePointerCapture(connectionPointerId);
+            }
+
+            if (connectionStarted && !cancelled) {
+                const elementUnderPointer = document.elementFromPoint(event.clientX, event.clientY);
+                const targetCard = elementUnderPointer ? elementUnderPointer.closest('.card') : null;
+                const targetId = targetCard ? Number(targetCard.dataset.cardId) : null;
+                finishConnectionDrag(targetId || null);
+                suppressClick = true;
+                setTimeout(() => {
+                    suppressClick = false;
+                }, 0);
+            } else if (cancelled) {
+                cancelActiveConnection();
+            }
+
+            connectionPointerId = null;
+            connectionStart = null;
+            connectionStarted = false;
+            lastPointerEvent = null;
+        }
+
+        div.addEventListener('pointerdown', (event) => {
+            if (event.button !== undefined && event.button !== 0) return;
+            if (shouldIgnoreConnectionStart(event.target)) return;
+
+            cancelActiveConnection();
+            connectionPointerId = event.pointerId;
+            connectionStart = { x: event.clientX, y: event.clientY };
+            connectionStarted = false;
+            lastPointerEvent = event;
+            div.setPointerCapture(connectionPointerId);
+
+            clearLongPressTimer();
+            longPressTimer = setTimeout(() => {
+                connectionStarted = true;
+                startConnectionDrag(card.id, lastPointerEvent || event);
+            }, LONG_PRESS_DURATION);
+        });
+
+        div.addEventListener('pointermove', (event) => {
+            if (connectionPointerId === null || event.pointerId !== connectionPointerId) return;
+            lastPointerEvent = event;
+
+            if (!connectionStarted) {
+                const dx = event.clientX - connectionStart.x;
+                const dy = event.clientY - connectionStart.y;
+                if (Math.sqrt(dx * dx + dy * dy) > MOVE_THRESHOLD) {
+                    clearLongPressTimer();
+                    if (div.hasPointerCapture(connectionPointerId)) {
+                        div.releasePointerCapture(connectionPointerId);
+                    }
+                    connectionPointerId = null;
+                    connectionStart = null;
+                    lastPointerEvent = null;
+                }
+                return;
+            }
+
+            updateConnectionDrag(event);
+        });
+
+        div.addEventListener('pointerup', (event) => endConnectionSequence(event));
+        div.addEventListener('pointercancel', (event) => endConnectionSequence(event, true));
+
         container.appendChild(div);
     }
 
     function render() {
+        cardElements.clear();
         container.innerHTML = "";
+        connectionLayer = null;
+        tempConnectionPath = null;
+        activeConnection = null;
+        ensureConnectionLayer();
         CardModel.getCards().forEach(createCardElement);
+        renderConnections();
     }
+
+    window.addEventListener('resize', () => {
+        if (container.childElementCount === 0) return;
+        renderConnections();
+    });
 
     return { render };
 })();

--- a/js/ui/export.js
+++ b/js/ui/export.js
@@ -116,13 +116,15 @@ const CardExport = (() => {
         return { content, mimeType: 'text/html', extension: 'html' };
     }
     
-    function generateJsonContent(cards) {
-        const content = JSON.stringify(cards, null, 2);
+    function generateJsonContent(cards, connectors) {
+        const content = JSON.stringify({ cards, connectors }, null, 2);
         return { content, mimeType: 'application/json', extension: 'json' };
     }
 
     function exportFilteredData(options) {
-        let cards = CardModel.getCards();
+        const state = CardModel.getState();
+        let cards = state.cards;
+        let connectors = state.connectors;
         if (options.selectedTags.length > 0) {
             cards = cards.filter(card => options.selectedTags.some(tag => card.tags.includes(tag)));
         }
@@ -134,12 +136,21 @@ const CardExport = (() => {
             alert("No cards match the selected filters.");
             return;
         }
-        
+
+        const cardIdSet = new Set(cards.map(card => card.id));
+        connectors = connectors.filter(connector => cardIdSet.has(connector.fromCardId) && cardIdSet.has(connector.toCardId));
+
         let result;
         switch(options.format) {
-            case 'html': result = generateHtmlContent(cards, options); break;
-            case 'json': result = generateJsonContent(cards); break;
-            default: result = generateMarkdownContent(cards, options); break;
+            case 'html':
+                result = generateHtmlContent(cards, options);
+                break;
+            case 'json':
+                result = generateJsonContent(cards, connectors);
+                break;
+            default:
+                result = generateMarkdownContent(cards, options);
+                break;
         }
 
         const blob = new Blob([result.content], { type: result.mimeType });


### PR DESCRIPTION
## Summary
- add connector data to the card model along with session persistence and validation helpers
- enhance the card UI with pointer-friendly dragging, long-press connector creation, and connection rendering
- style the connection layer and include connectors in filtered JSON exports

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e98ab13608329987222f8e3d6b387)