### PR TITLE
Improve card connection long-press affordance

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -24,8 +24,8 @@ body {
 /* --- Card Component --- */
 .card {
     position: absolute;
-    width: 170px; /* Increased from 150px */
-    padding: 10px;
+    width: 190px;
+    padding: 12px;
     background: #fff;
     border: 2px solid #ccc;
     border-radius: 8px;
@@ -53,6 +53,44 @@ body {
     font-size: 0.9em;
     min-height: 20px;
     cursor: pointer;
+}
+
+.card .connection-pad {
+    margin-top: 10px;
+    padding: 8px 10px;
+    background: #eef2ff;
+    border: 2px dashed #a5b4fc;
+    border-radius: 6px;
+    text-align: center;
+    font-size: 0.85em;
+    font-weight: 600;
+    letter-spacing: 0.3px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    cursor: pointer;
+    user-select: none;
+    touch-action: none;
+    color: #3730a3;
+    transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.card .connection-pad-icon {
+    font-size: 1.1em;
+}
+
+.card .connection-pad.press-ready {
+    border-style: solid;
+    border-color: #6366f1;
+    background: #e0e7ff;
+}
+
+.card .connection-pad.active {
+    border-color: #4338ca;
+    background: #c7d2fe;
+    color: #1e1b4b;
+    transform: scale(1.02);
 }
 
 .card .tags {

--- a/js/ui/cards.js
+++ b/js/ui/cards.js
@@ -2,7 +2,7 @@ const CardUI = (() => {
     const container = document.getElementById("card-container");
     const svgNS = "http://www.w3.org/2000/svg";
     const LONG_PRESS_DURATION = 500;
-    const MOVE_THRESHOLD = 6;
+    const MOVE_THRESHOLD = 24;
     const RELATION_SUGGESTIONS = [
         'relates to',
         'type of',
@@ -322,6 +322,13 @@ const CardUI = (() => {
 
         div.appendChild(palette);
 
+        const connectionPad = document.createElement('div');
+        connectionPad.classList.add('connection-pad');
+        connectionPad.setAttribute('role', 'button');
+        connectionPad.setAttribute('aria-label', 'Hold to start connecting this card to another');
+        connectionPad.innerHTML = '<span class="connection-pad-icon">⤳</span><span class="connection-pad-text">Hold to connect</span>';
+        div.appendChild(connectionPad);
+
         const tagContainer = document.createElement("div");
         tagContainer.classList.add("tags");
         div.appendChild(tagContainer);
@@ -383,12 +390,18 @@ const CardUI = (() => {
             }
         }
 
+        function resetConnectionVisualState() {
+            connectionPad.classList.remove('press-ready');
+            connectionPad.classList.remove('active');
+        }
+
         function endConnectionSequence(event, cancelled = false) {
             if (connectionPointerId === null || event.pointerId !== connectionPointerId) {
                 return;
             }
 
             clearLongPressTimer();
+            resetConnectionVisualState();
             if (div.hasPointerCapture(connectionPointerId)) {
                 div.releasePointerCapture(connectionPointerId);
             }
@@ -424,8 +437,12 @@ const CardUI = (() => {
             div.setPointerCapture(connectionPointerId);
 
             clearLongPressTimer();
+            resetConnectionVisualState();
+            connectionPad.classList.add('press-ready');
             longPressTimer = setTimeout(() => {
                 connectionStarted = true;
+                connectionPad.classList.remove('press-ready');
+                connectionPad.classList.add('active');
                 startConnectionDrag(card.id, lastPointerEvent || event);
             }, LONG_PRESS_DURATION);
         });
@@ -439,6 +456,7 @@ const CardUI = (() => {
                 const dy = event.clientY - connectionStart.y;
                 if (Math.sqrt(dx * dx + dy * dy) > MOVE_THRESHOLD) {
                     clearLongPressTimer();
+                    resetConnectionVisualState();
                     if (div.hasPointerCapture(connectionPointerId)) {
                         div.releasePointerCapture(connectionPointerId);
                     }


### PR DESCRIPTION
## Summary
- add a dedicated hold-to-connect pad to each card with clear visual states and accessible metadata
- relax the pointer jitter threshold and reset indicators so long-press gestures are less likely to cancel
- widen cards to comfortably fit the new connection handle styling

## Testing
- not run (not available)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ea088815c8329a435f6d37ee5fc78)