### PR TITLE
Add connectable relationship nodes and update exports

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -207,6 +207,35 @@ body {
     user-select: none;
 }
 
+.connector-node {
+    cursor: pointer;
+    transition: transform 0.2s;
+}
+
+.connector-node:hover {
+    transform: scale(1.04);
+}
+
+.connector-node-bg {
+    fill: #f4f6fb;
+    stroke: #4a6fa5;
+    stroke-width: 1.5px;
+    opacity: 0.95;
+}
+
+.connector-node:hover .connector-node-bg {
+    fill: #e3ecff;
+}
+
+.connector-node-active .connector-node-bg {
+    fill: #d4e4ff;
+    stroke: #1e4d8f;
+}
+
+.connector-node-active {
+    transform: scale(1.08);
+}
+
 .temp-connector {
     stroke-dasharray: 6 4;
     opacity: 0.7;

--- a/js/model.js
+++ b/js/model.js
@@ -4,6 +4,35 @@ const CardModel = (() => {
     let idCounter = 1;
     let connectorIdCounter = 1;
 
+    function normalizeEndpoint(endpoint, fallbackType = 'card') {
+        if (endpoint && typeof endpoint === 'object' && 'id' in endpoint) {
+            const type = endpoint.type === 'connector' ? 'connector' : 'card';
+            const id = Number(endpoint.id);
+            if (!Number.isFinite(id)) return null;
+            return { type, id };
+        }
+
+        const id = Number(endpoint);
+        if (!Number.isFinite(id)) return null;
+        return { type: fallbackType, id };
+    }
+
+    function endpointExists(endpoint) {
+        if (!endpoint) return false;
+        if (endpoint.type === 'card') {
+            return cards.some(c => c.id === endpoint.id);
+        }
+        if (endpoint.type === 'connector') {
+            return connectors.some(c => c.id === endpoint.id);
+        }
+        return false;
+    }
+
+    function clonePosition(position) {
+        if (!position || typeof position.x !== 'number' || typeof position.y !== 'number') return null;
+        return { x: position.x, y: position.y };
+    }
+
     function addCard(title = "New Title", blurb = "Click to edit...") {
         const card = {
             id: idCounter++,
@@ -32,17 +61,42 @@ const CardModel = (() => {
         return connectors;
     }
 
-    function addConnector(fromCardId, toCardId, type = 'relates to') {
-        const fromExists = cards.some(c => c.id === fromCardId);
-        const toExists = cards.some(c => c.id === toCardId);
-        if (!fromExists || !toExists || fromCardId === toCardId) {
+    function getConnectorPosition(id) {
+        const connector = connectors.find(c => c.id === id);
+        if (!connector) return null;
+        if (!connector.position) return null;
+        return clonePosition(connector.position);
+    }
+
+    function setConnectorPosition(id, position, options = {}) {
+        const connector = connectors.find(c => c.id === id);
+        if (!connector || !position) return;
+        const { autoPosition } = options;
+        connector.position = { x: position.x, y: position.y };
+        if (typeof autoPosition === 'boolean') {
+            connector.autoPosition = autoPosition;
+        }
+    }
+
+    function addConnector(fromInput, toInput, type = 'relates to', options = {}) {
+        const from = normalizeEndpoint(fromInput, 'card');
+        const to = normalizeEndpoint(toInput, 'card');
+        if (!from || !to) return null;
+
+        if (!endpointExists(from) || !endpointExists(to)) {
+            return null;
+        }
+
+        if (from.type === to.type && from.id === to.id) {
             return null;
         }
 
         const normalizedType = type && type.trim() ? type.trim() : 'relates to';
         const duplicate = connectors.some(connector =>
-            connector.fromCardId === fromCardId &&
-            connector.toCardId === toCardId &&
+            connector.from.type === from.type &&
+            connector.from.id === from.id &&
+            connector.to.type === to.type &&
+            connector.to.id === to.id &&
             connector.type.toLowerCase() === normalizedType.toLowerCase()
         );
         if (duplicate) {
@@ -51,9 +105,11 @@ const CardModel = (() => {
 
         const connector = {
             id: connectorIdCounter++,
-            fromCardId,
-            toCardId,
-            type: normalizedType
+            from,
+            to,
+            type: normalizedType,
+            position: options.position ? clonePosition(options.position) : { x: 0, y: 0 },
+            autoPosition: options.autoPosition !== undefined ? options.autoPosition : true
         };
 
         connectors.push(connector);
@@ -66,10 +122,20 @@ const CardModel = (() => {
     }
 
     function deleteConnector(id) {
-        const index = connectors.findIndex(c => c.id === id);
-        if (index > -1) {
-            connectors.splice(index, 1);
-        }
+        const toRemove = new Set();
+        const collectDependents = (targetId) => {
+            if (toRemove.has(targetId)) return;
+            toRemove.add(targetId);
+            connectors
+                .filter(connector =>
+                    (connector.from.type === 'connector' && connector.from.id === targetId) ||
+                    (connector.to.type === 'connector' && connector.to.id === targetId)
+                )
+                .forEach(connector => collectDependents(connector.id));
+        };
+
+        collectDependents(id);
+        connectors = connectors.filter(connector => !toRemove.has(connector.id));
     }
 
     function getConnector(id) {
@@ -93,21 +159,43 @@ const CardModel = (() => {
             if (Array.isArray(loadedData.connectors)) {
                 const seen = new Set();
                 const sanitized = [];
+
                 loadedData.connectors.forEach(connector => {
-                    if (!cardIds.has(connector.fromCardId) || !cardIds.has(connector.toCardId) || connector.fromCardId === connector.toCardId) {
+                    const from = connector.from ? normalizeEndpoint(connector.from) : normalizeEndpoint(connector.fromCardId, 'card');
+                    const to = connector.to ? normalizeEndpoint(connector.to) : normalizeEndpoint(connector.toCardId, 'card');
+                    if (!from || !to) {
                         return;
                     }
+
+                    const fromValid = from.type === 'card' ? cardIds.has(from.id) : true;
+                    const toValid = to.type === 'card' ? cardIds.has(to.id) : true;
+                    if (!fromValid || !toValid) {
+                        return;
+                    }
+
+                    if (from.type === to.type && from.id === to.id) {
+                        return;
+                    }
+
                     const type = connector.type && typeof connector.type === 'string' && connector.type.trim() ? connector.type.trim() : 'relates to';
-                    const key = `${connector.fromCardId}->${connector.toCardId}:${type.toLowerCase()}`;
+                    const key = `${from.type}:${from.id}->${to.type}:${to.id}:${type.toLowerCase()}`;
                     if (seen.has(key)) {
                         return;
                     }
                     seen.add(key);
+
+                    let position = null;
+                    if (connector.position && typeof connector.position.x === 'number' && typeof connector.position.y === 'number') {
+                        position = { x: connector.position.x, y: connector.position.y };
+                    }
+
                     sanitized.push({
                         id: typeof connector.id === 'number' && Number.isFinite(connector.id) ? connector.id : null,
-                        fromCardId: connector.fromCardId,
-                        toCardId: connector.toCardId,
-                        type
+                        from,
+                        to,
+                        type,
+                        position,
+                        autoPosition: connector.autoPosition !== undefined ? Boolean(connector.autoPosition) : true
                     });
                 });
 
@@ -120,9 +208,11 @@ const CardModel = (() => {
                 let nextId = maxId + 1;
                 connectors = sanitized.map(connector => ({
                     id: typeof connector.id === 'number' ? connector.id : nextId++,
-                    fromCardId: connector.fromCardId,
-                    toCardId: connector.toCardId,
-                    type: connector.type
+                    from: connector.from,
+                    to: connector.to,
+                    type: connector.type,
+                    position: connector.position ? { x: connector.position.x, y: connector.position.y } : { x: 0, y: 0 },
+                    autoPosition: connector.autoPosition !== undefined ? connector.autoPosition : true
                 }));
             } else {
                 connectors = [];
@@ -134,13 +224,52 @@ const CardModel = (() => {
 
         idCounter = Math.max(0, ...cards.map(c => c.id)) + 1;
         connectorIdCounter = Math.max(0, ...connectors.map(c => c.id)) + 1;
+
+        // Remove connectors that reference non-existent connectors after ids reset
+        let stable = false;
+        while (!stable) {
+            stable = true;
+            const connectorIds = new Set(connectors.map(connector => connector.id));
+            const filtered = connectors.filter(connector => {
+                const fromValid = connector.from.type === 'connector' ? connectorIds.has(connector.from.id) : true;
+                const toValid = connector.to.type === 'connector' ? connectorIds.has(connector.to.id) : true;
+                return fromValid && toValid;
+            });
+            if (filtered.length !== connectors.length) {
+                connectors = filtered;
+                stable = false;
+            }
+        }
     }
 
     function deleteCard(id) {
         const cardIndex = cards.findIndex(c => c.id === id);
         if (cardIndex > -1) {
             cards.splice(cardIndex, 1);
-            connectors = connectors.filter(connector => connector.fromCardId !== id && connector.toCardId !== id);
+            const removedConnectors = connectors
+                .filter(connector =>
+                    (connector.from.type === 'card' && connector.from.id === id) ||
+                    (connector.to.type === 'card' && connector.to.id === id)
+                )
+                .map(connector => connector.id);
+
+            const toRemove = new Set(removedConnectors);
+            const collectDependents = (targetId) => {
+                connectors
+                    .filter(connector =>
+                        (connector.from.type === 'connector' && connector.from.id === targetId) ||
+                        (connector.to.type === 'connector' && connector.to.id === targetId)
+                    )
+                    .forEach(connector => {
+                        if (!toRemove.has(connector.id)) {
+                            toRemove.add(connector.id);
+                            collectDependents(connector.id);
+                        }
+                    });
+            };
+
+            removedConnectors.forEach(collectDependents);
+            connectors = connectors.filter(connector => !toRemove.has(connector.id));
         }
     }
 
@@ -149,6 +278,8 @@ const CardModel = (() => {
         updateCard,
         getCards,
         getConnectors,
+        getConnectorPosition,
+        setConnectorPosition,
         addConnector,
         updateConnector,
         deleteConnector,

--- a/js/ui/cards.js
+++ b/js/ui/cards.js
@@ -46,6 +46,44 @@ const CardUI = (() => {
         };
     }
 
+    function getConnectorCenter(connectorId) {
+        const position = CardModel.getConnectorPosition(connectorId);
+        if (!position) return null;
+        return { x: position.x, y: position.y };
+    }
+
+    function getEndpointCenter(endpoint) {
+        if (!endpoint) return null;
+        if (endpoint.type === 'card') {
+            return getCardCenter(endpoint.id);
+        }
+        if (endpoint.type === 'connector') {
+            return getConnectorCenter(endpoint.id);
+        }
+        return null;
+    }
+
+    function identifyTargetElement(element) {
+        if (!element) return null;
+        const cardEl = element.closest && element.closest('.card');
+        if (cardEl) {
+            return { type: 'card', id: Number(cardEl.dataset.cardId) };
+        }
+        const connectorEl = element.closest && element.closest('.connector-node');
+        if (connectorEl) {
+            return { type: 'connector', id: Number(connectorEl.dataset.connectorId) };
+        }
+        if (element.classList && element.classList.contains('connector-node')) {
+            return { type: 'connector', id: Number(element.dataset.connectorId) };
+        }
+        return null;
+    }
+
+    function findTargetAtPoint(clientX, clientY) {
+        const element = document.elementFromPoint(clientX, clientY);
+        return identifyTargetElement(element);
+    }
+
     function computeControlPoint(start, end) {
         const midX = (start.x + end.x) / 2;
         const midY = (start.y + end.y) / 2;
@@ -89,9 +127,11 @@ const CardUI = (() => {
         const layer = ensureConnectionLayer();
         layer.innerHTML = '';
 
-        CardModel.getConnectors().forEach(connector => {
-            const start = getCardCenter(connector.fromCardId);
-            const end = getCardCenter(connector.toCardId);
+        const connectors = CardModel.getConnectors();
+
+        connectors.forEach(connector => {
+            const start = getEndpointCenter(connector.from);
+            const end = getEndpointCenter(connector.to);
             if (!start || !end) {
                 return;
             }
@@ -103,16 +143,45 @@ const CardUI = (() => {
             path.dataset.connectorId = connector.id;
             layer.appendChild(path);
 
-            const midPoint = computeQuadraticPoint(start, control, end, 0.5);
+            let nodePosition;
+            if (connector.autoPosition || !connector.position) {
+                nodePosition = computeQuadraticPoint(start, control, end, 0.5);
+                CardModel.setConnectorPosition(connector.id, nodePosition, { autoPosition: true });
+            } else {
+                nodePosition = { x: connector.position.x, y: connector.position.y };
+            }
+
+            const group = document.createElementNS(svgNS, 'g');
+            group.classList.add('connector-node');
+            group.dataset.connectorId = connector.id;
+
+            const background = document.createElementNS(svgNS, 'rect');
+            background.classList.add('connector-node-bg');
+            group.appendChild(background);
+
             const text = document.createElementNS(svgNS, 'text');
             text.classList.add('connector-label');
-            text.setAttribute('x', midPoint.x);
-            text.setAttribute('y', midPoint.y - 6);
             text.setAttribute('text-anchor', 'middle');
-            text.setAttribute('dominant-baseline', 'central');
+            text.setAttribute('dominant-baseline', 'middle');
             text.textContent = connector.type;
-            text.dataset.connectorId = connector.id;
-            layer.appendChild(text);
+            group.appendChild(text);
+
+            layer.appendChild(group);
+
+            const paddingX = 12;
+            const textLength = text.getComputedTextLength();
+            const height = 24;
+            const width = Math.max(textLength + paddingX * 2, height);
+
+            background.setAttribute('x', nodePosition.x - width / 2);
+            background.setAttribute('y', nodePosition.y - height / 2);
+            background.setAttribute('width', width);
+            background.setAttribute('height', height);
+            background.setAttribute('rx', height / 2);
+            background.setAttribute('ry', height / 2);
+
+            text.setAttribute('x', nodePosition.x);
+            text.setAttribute('y', nodePosition.y);
 
             const editHandler = () => editConnector(connector.id);
             const deleteHandler = (event) => {
@@ -121,9 +190,10 @@ const CardUI = (() => {
             };
 
             path.addEventListener('click', editHandler);
-            text.addEventListener('click', editHandler);
             path.addEventListener('contextmenu', deleteHandler);
-            text.addEventListener('contextmenu', deleteHandler);
+            group.addEventListener('contextmenu', deleteHandler);
+
+            setupConnectorNodeInteractions(group, connector.id);
         });
 
         if (activeConnection && tempConnectionPath) {
@@ -131,13 +201,96 @@ const CardUI = (() => {
         }
     }
 
-    function startConnectionDrag(cardId, pointerEvent) {
-        const start = getCardCenter(cardId);
+    function setupConnectorNodeInteractions(group, connectorId) {
+        let pointerId = null;
+        let longPressTimer = null;
+        let connectionStarted = false;
+        let startPoint = null;
+        let lastPointerEvent = null;
+
+        const clearTimer = () => {
+            if (longPressTimer) {
+                clearTimeout(longPressTimer);
+                longPressTimer = null;
+            }
+        };
+
+        function resetState(cancelConnection = false) {
+            clearTimer();
+            if (pointerId !== null && group.hasPointerCapture && group.hasPointerCapture(pointerId)) {
+                group.releasePointerCapture(pointerId);
+            }
+            pointerId = null;
+            startPoint = null;
+            lastPointerEvent = null;
+            if (cancelConnection) {
+                cancelActiveConnection();
+            }
+            connectionStarted = false;
+            group.classList.remove('connector-node-active');
+        }
+
+        group.addEventListener('pointerdown', (event) => {
+            if (event.button !== undefined && event.button !== 0) return;
+            event.stopPropagation();
+            event.preventDefault();
+            cancelActiveConnection();
+            pointerId = event.pointerId;
+            startPoint = { x: event.clientX, y: event.clientY };
+            lastPointerEvent = event;
+            connectionStarted = false;
+            group.classList.remove('connector-node-active');
+            if (group.setPointerCapture) {
+                group.setPointerCapture(pointerId);
+            }
+            clearTimer();
+            longPressTimer = setTimeout(() => {
+                connectionStarted = true;
+                group.classList.add('connector-node-active');
+                startConnectionDrag({ type: 'connector', id: connectorId }, lastPointerEvent || event);
+            }, LONG_PRESS_DURATION);
+        });
+
+        group.addEventListener('pointermove', (event) => {
+            if (pointerId === null || event.pointerId !== pointerId) return;
+            lastPointerEvent = event;
+            if (!connectionStarted) {
+                const dx = event.clientX - startPoint.x;
+                const dy = event.clientY - startPoint.y;
+                if (Math.sqrt(dx * dx + dy * dy) > MOVE_THRESHOLD) {
+                    resetState(true);
+                }
+                return;
+            }
+            updateConnectionDrag(event);
+        });
+
+        const finalizeConnection = (event, cancelled = false) => {
+            if (pointerId === null || event.pointerId !== pointerId) return;
+            const started = connectionStarted;
+            resetState(cancelled);
+            if (!started) {
+                if (!cancelled) {
+                    editConnector(connectorId);
+                }
+                return;
+            }
+
+            const target = cancelled ? null : findTargetAtPoint(event.clientX, event.clientY);
+            finishConnectionDrag(target);
+        };
+
+        group.addEventListener('pointerup', (event) => finalizeConnection(event));
+        group.addEventListener('pointercancel', (event) => finalizeConnection(event, true));
+    }
+
+    function startConnectionDrag(source, pointerEvent) {
+        const start = getEndpointCenter(source);
         if (!start) return;
         ensureConnectionLayer();
 
         activeConnection = {
-            fromCardId: cardId,
+            from: { type: source.type, id: source.id },
             start
         };
 
@@ -154,25 +307,37 @@ const CardUI = (() => {
             x: pointerEvent.clientX - containerRect.left,
             y: pointerEvent.clientY - containerRect.top
         };
-        const { start } = activeConnection;
+        const start = getEndpointCenter(activeConnection.from) || activeConnection.start;
         const control = computeControlPoint(start, end);
         tempConnectionPath.setAttribute('d', `M ${start.x} ${start.y} Q ${control.x} ${control.y} ${end.x} ${end.y}`);
     }
 
-    function finishConnectionDrag(targetCardId) {
+    function finishConnectionDrag(targetEndpoint) {
         if (tempConnectionPath && tempConnectionPath.parentNode) {
             tempConnectionPath.parentNode.removeChild(tempConnectionPath);
         }
         tempConnectionPath = null;
 
-        if (activeConnection && targetCardId && targetCardId !== activeConnection.fromCardId) {
+        if (activeConnection && targetEndpoint && (targetEndpoint.type !== activeConnection.from.type || targetEndpoint.id !== activeConnection.from.id)) {
             const suggestionText = `Suggestions: ${RELATION_SUGGESTIONS.join(', ')}`;
-            const relationType = prompt(`Relationship type between cards?\n${suggestionText}`, RELATION_SUGGESTIONS[0]);
+            let defaultSuggestion = RELATION_SUGGESTIONS[0];
+            if (activeConnection.from.type === 'connector') {
+                const sourceConnector = CardModel.getConnector(activeConnection.from.id);
+                if (sourceConnector && sourceConnector.type) {
+                    defaultSuggestion = sourceConnector.type;
+                }
+            }
+            const relationType = prompt(`Relationship type between items?\n${suggestionText}`, defaultSuggestion);
             if (relationType !== null) {
                 const trimmed = relationType.trim();
-                const created = CardModel.addConnector(activeConnection.fromCardId, targetCardId, trimmed || RELATION_SUGGESTIONS[0]);
+                const created = CardModel.addConnector(
+                    { type: activeConnection.from.type, id: activeConnection.from.id },
+                    { type: targetEndpoint.type, id: targetEndpoint.id },
+                    trimmed || defaultSuggestion,
+                    { autoPosition: true }
+                );
                 if (!created) {
-                    alert('A connector with this relationship already exists between the selected cards.');
+                    alert('A connector with this relationship already exists between the selected items.');
                 }
                 renderConnections();
             }
@@ -187,6 +352,7 @@ const CardUI = (() => {
         }
         tempConnectionPath = null;
         activeConnection = null;
+        document.querySelectorAll('.connector-node-active').forEach(el => el.classList.remove('connector-node-active'));
     }
 
     function createCardElement(card) {
@@ -407,10 +573,8 @@ const CardUI = (() => {
             }
 
             if (connectionStarted && !cancelled) {
-                const elementUnderPointer = document.elementFromPoint(event.clientX, event.clientY);
-                const targetCard = elementUnderPointer ? elementUnderPointer.closest('.card') : null;
-                const targetId = targetCard ? Number(targetCard.dataset.cardId) : null;
-                finishConnectionDrag(targetId || null);
+                const target = findTargetAtPoint(event.clientX, event.clientY);
+                finishConnectionDrag(target || null);
                 suppressClick = true;
                 setTimeout(() => {
                     suppressClick = false;
@@ -443,7 +607,7 @@ const CardUI = (() => {
                 connectionStarted = true;
                 connectionPad.classList.remove('press-ready');
                 connectionPad.classList.add('active');
-                startConnectionDrag(card.id, lastPointerEvent || event);
+                startConnectionDrag({ type: 'card', id: card.id }, lastPointerEvent || event);
             }, LONG_PRESS_DURATION);
         });
 

--- a/js/ui/export.js
+++ b/js/ui/export.js
@@ -60,12 +60,62 @@ const CardExport = (() => {
 
     // --- Content Generators for Each Format ---
 
-    function generateMarkdownContent(cards, options) {
+    function getConnectorLabel(connector) {
+        if (!connector) {
+            return 'relates to';
+        }
+        const label = connector.type !== undefined && connector.type !== null ? connector.type.toString().trim() : '';
+        return label || 'relates to';
+    }
+
+    function describeEndpoint(endpoint, cardLookup, connectorLookup) {
+        if (!endpoint) return 'Unknown';
+        if (endpoint.type === 'card') {
+            const card = cardLookup.get(endpoint.id);
+            if (!card) {
+                return `Card #${endpoint.id}`;
+            }
+            const title = card.title ? card.title.trim() : `Card #${card.id}`;
+            return card.nucleus ? `(Nucleus) ${title}` : title;
+        }
+        if (endpoint.type === 'connector') {
+            const connector = connectorLookup.get(endpoint.id);
+            if (!connector) {
+                return `Connector #${endpoint.id}`;
+            }
+            const label = getConnectorLabel(connector);
+            return `Connector #${connector.id} (“${label}”)`;
+        }
+        return 'Unknown';
+    }
+
+    function describeEndpointHtml(endpoint, cardLookup, connectorLookup) {
+        if (!endpoint) return 'Unknown';
+        if (endpoint.type === 'card') {
+            const card = cardLookup.get(endpoint.id);
+            if (!card) {
+                return `Card #${endpoint.id}`;
+            }
+            const title = card.title ? card.title.trim() : `Card #${card.id}`;
+            return card.nucleus ? `<strong>(Nucleus) ${title}</strong>` : `<strong>${title}</strong>`;
+        }
+        if (endpoint.type === 'connector') {
+            const connector = connectorLookup.get(endpoint.id);
+            if (!connector) {
+                return `Connector #${endpoint.id}`;
+            }
+            const label = getConnectorLabel(connector);
+            return `<strong>Connector #${connector.id}</strong> (“${label}”)`;
+        }
+        return 'Unknown';
+    }
+
+    function generateMarkdownContent(cards, connectors, options) {
         const { tagsMap, untaggedCards } = processCards(cards);
         const sortedTags = Object.keys(tagsMap).sort();
         const now = new Date();
         const timestamp = `${now.toLocaleDateString()} at ${now.toLocaleTimeString()}`;
-        
+
         let content = `# ${options.title}\n\n*Generated on: ${timestamp}*\n\n---\n\n`;
 
         const createList = (cardList) => {
@@ -84,10 +134,28 @@ const CardExport = (() => {
             content += `## Untagged Cards\n${createList(untaggedCards)}\n---\n\n`;
         }
 
+        if (connectors.length > 0) {
+            const cardLookup = new Map(cards.map(card => [card.id, card]));
+            const connectorLookup = new Map(connectors.map(connector => [connector.id, connector]));
+            const sortedConnectors = [...connectors].sort((a, b) => {
+                const typeCompare = getConnectorLabel(a).localeCompare(getConnectorLabel(b));
+                if (typeCompare !== 0) return typeCompare;
+                return a.id - b.id;
+            });
+            content += `## Connections\n`;
+            sortedConnectors.forEach(connector => {
+                const from = describeEndpoint(connector.from, cardLookup, connectorLookup);
+                const to = describeEndpoint(connector.to, cardLookup, connectorLookup);
+                const label = getConnectorLabel(connector);
+                content += `- **${label}**: ${from} ➔ ${to}\n`;
+            });
+            content += `\n---\n\n`;
+        }
+
         return { content, mimeType: 'text/markdown', extension: 'md' };
     }
 
-    function generateHtmlContent(cards, options) {
+    function generateHtmlContent(cards, connectors, options) {
         const { tagsMap, untaggedCards } = processCards(cards);
         const sortedTags = Object.keys(tagsMap).sort();
         const now = new Date();
@@ -111,7 +179,25 @@ const CardExport = (() => {
         if (untaggedCards.length > 0) {
             content += `<h2>Untagged Cards</h2>${createList(untaggedCards)}`;
         }
-        
+
+        if (connectors.length > 0) {
+            const cardLookup = new Map(cards.map(card => [card.id, card]));
+            const connectorLookup = new Map(connectors.map(connector => [connector.id, connector]));
+            const sortedConnectors = [...connectors].sort((a, b) => {
+                const typeCompare = getConnectorLabel(a).localeCompare(getConnectorLabel(b));
+                if (typeCompare !== 0) return typeCompare;
+                return a.id - b.id;
+            });
+            content += `<h2>Connections</h2><ul>`;
+            sortedConnectors.forEach(connector => {
+                const from = describeEndpointHtml(connector.from, cardLookup, connectorLookup);
+                const to = describeEndpointHtml(connector.to, cardLookup, connectorLookup);
+                const label = getConnectorLabel(connector);
+                content += `<li><strong>${label}</strong>: ${from} ➔ ${to}</li>`;
+            });
+            content += `</ul>`;
+        }
+
         content += `</body></html>`;
         return { content, mimeType: 'text/html', extension: 'html' };
     }
@@ -138,18 +224,50 @@ const CardExport = (() => {
         }
 
         const cardIdSet = new Set(cards.map(card => card.id));
-        connectors = connectors.filter(connector => cardIdSet.has(connector.fromCardId) && cardIdSet.has(connector.toCardId));
+        const initialConnectors = state.connectors.filter(connector => {
+            if (connector.from.type === 'card' && !cardIdSet.has(connector.from.id)) {
+                return false;
+            }
+            if (connector.to.type === 'card' && !cardIdSet.has(connector.to.id)) {
+                return false;
+            }
+            return true;
+        });
+
+        const allowedKeys = new Set(Array.from(cardIdSet).map(id => `card:${id}`));
+        const pending = new Map(initialConnectors.map(connector => [connector.id, connector]));
+        const includedConnectors = [];
+
+        let expanded = true;
+        while (expanded) {
+            expanded = false;
+            for (const [connectorId, connector] of Array.from(pending.entries())) {
+                const fromKey = `${connector.from.type}:${connector.from.id}`;
+                const toKey = `${connector.to.type}:${connector.to.id}`;
+                if (allowedKeys.has(fromKey) && allowedKeys.has(toKey)) {
+                    includedConnectors.push(connector);
+                    pending.delete(connectorId);
+                    const connectorKey = `connector:${connectorId}`;
+                    if (!allowedKeys.has(connectorKey)) {
+                        allowedKeys.add(connectorKey);
+                    }
+                    expanded = true;
+                }
+            }
+        }
+
+        connectors = includedConnectors;
 
         let result;
         switch(options.format) {
             case 'html':
-                result = generateHtmlContent(cards, options);
+                result = generateHtmlContent(cards, connectors, options);
                 break;
             case 'json':
                 result = generateJsonContent(cards, connectors);
                 break;
             default:
-                result = generateMarkdownContent(cards, options);
+                result = generateMarkdownContent(cards, connectors, options);
                 break;
         }
 


### PR DESCRIPTION
## Summary
- treat connectors as first-class endpoints in the data model, preserving manual positions and cascading deletes
- render pill-shaped connector nodes that support long-press linking, editing, and context deletion while updating connection flow
- enhance exports with connector descriptions and include new node styling

## Testing
- not run (not available)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ea299f1ec8329a5f5e15d4205f5b0)